### PR TITLE
fix: use updated undici to fix response bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "fast-jwt": "^3.3.2",
-    "undici": "^5.28.2"
+    "undici": "^6.0.0"
   },
   "devDependencies": {
     "fastify": "^4.24.3",

--- a/tests/interceptor.test.js
+++ b/tests/interceptor.test.js
@@ -469,7 +469,8 @@ test('only retries on provided status codes', async (t) => {
     }
   })
 
-  await assert.rejects(request(`http://localhost:${mainServer.address().port}`, { dispatcher }))
+  const response = await request(`http://localhost:${mainServer.address().port}`, { dispatcher })
+  assert.strictEqual(response.statusCode, 403)
 })
 
 test('error handling on creation', async (t) => {


### PR DESCRIPTION
HTTP status codes in requests that are not retried are correctly passed through with fix in undici https://github.com/nodejs/undici/pull/2496